### PR TITLE
Fixes file view window stuck on screen after unfocusing

### DIFF
--- a/lua/rip/init.lua
+++ b/lua/rip/init.lua
@@ -124,6 +124,7 @@ function build_window()
 
     file_list_buf = vim.api.nvim_create_buf(false, true)
     file_list_win = vim.api.nvim_open_win(file_list_buf, true, file_list_opts)
+    vim.api.nvim_command("autocmd BufLeave <buffer> lua close_window()")
 end
 
 function get_entries_from_files(files)
@@ -205,6 +206,7 @@ end
 
 function close_window()
     vim.api.nvim_win_close(file_list_win, true)
+    vim.api.nvim_command("autocmd! BufLeave <buffer>")
 end
 
 function collapse_file()


### PR DESCRIPTION
## Problem

If the file list window was open and the user moved to another window (either by ctrl + w await or clicking elsewhere) the window would not close and stay stuck on the screen.

Trying to refocus the screen was not possible either since it is marked as not focusable https://github.com/lucaspellegrinelli/rip.nvim/blob/6b97c76406a16174fed9483aa5eb5ce03e6510ff/lua/rip/init.lua#L121

This made so the only way to fix the problem is to quit NeoVim and reopen it.

## Fix

This Pull Request fixes the said problem by adding an `autocmd` right after the screen is opened that overrides the action when the event `BufLeave` happens. The action is overwritten to the function `close_window()`.

https://github.com/lucaspellegrinelli/rip.nvim/blob/6b97c76406a16174fed9483aa5eb5ce03e6510ff/lua/rip/init.lua#L127

The `autocmd` is also reset to default after the window is closed.

https://github.com/lucaspellegrinelli/rip.nvim/blob/6b97c76406a16174fed9483aa5eb5ce03e6510ff/lua/rip/init.lua#L209