### PR TITLE
Replaces "a" keybind from toggling a file to toggling all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ rip.setup({
     keybinds = {
         toggle_mark = "y",
         toggle_collapse = "l",
-        toggle_mark_all_in_file = "p",
+        toggle_mark_all = "p",
     },
 })
 ```
@@ -54,9 +54,9 @@ In the example above, we replaced some of the shortcuts the utility has (like re
 ```
 X. key_binding_key (default_value) - Description
 
-1. toggle_mark (x) - Selecting/Unselecting a specific occurence to be replaced
+1. toggle_mark (x) - Selecting/Unselecting a specific occurences or files to be replaced
 2. toggle_collapse (c) - Collapsing/Uncollapsing the occurences of a specific file
-3. toggle_mark_all_in_file (a) - Selecting/Unselecting all the occurences in a specific file
+3. toggle_mark_all (a) - Selecting/Unselecting all the occurences found in all files
 4. confirm_replace (<CR>) - Close the window and replacing all selected occurences
 5. cancel_replace (<Esc>) - Close the window and NOT replacing any occurences
 ```

--- a/lua/rip/init.lua
+++ b/lua/rip/init.lua
@@ -10,6 +10,7 @@ local selected_options = {}
 local option_per_line = {}
 local collapsed_files = {}
 local marked_files = {}
+local all_files_marked = false
 
 local file_list_buf = nil
 local file_list_win = nil
@@ -19,7 +20,7 @@ local files = {}
 local keybinds = {
     toggle_mark = "x",
     toggle_collapse = "c",
-    toggle_mark_all_in_file = "a",
+    toggle_mark_all = "a",
     confirm_replace = "<CR>",
     cancel_replace = "<Esc>",
 }
@@ -89,8 +90,8 @@ function set_keybinds()
             { noremap = true, silent = true })
         vim.api.nvim_buf_set_keymap(file_list_buf, "n", keybinds["toggle_collapse"], ":lua collapse_file()<CR>",
             { noremap = true, silent = true })
-        vim.api.nvim_buf_set_keymap(file_list_buf, "n", keybinds["toggle_mark_all_in_file"],
-            ":lua toggle_mark_all_in_file()<CR>",
+        vim.api.nvim_buf_set_keymap(file_list_buf, "n", keybinds["toggle_mark_all"],
+            ":lua toggle_mark_all()<CR>",
             { noremap = true, silent = true })
     end
 
@@ -270,6 +271,25 @@ function toggle_mark_all_in_file()
 
             local tmp_line_text = vim.fn.getline(i)
             local new_line_text = get_marked_line(tmp_line_text, not was_marked)
+            set_highlighted_text(file_list_buf, i, new_line_text, search_string)
+        end
+    end
+
+    vim.api.nvim_buf_set_option(file_list_buf, "modifiable", false)
+end
+
+function toggle_mark_all()
+    vim.api.nvim_buf_set_option(file_list_buf, "modifiable", true)
+
+    all_files_marked = not all_files_marked
+
+    for i = 1, vim.fn.line('$') do
+        local line_text = vim.fn.getline(i)
+        if is_line_number(line_text) then
+            local option = option_per_line[i + 1]
+            set_selected_state(option.file, option.line_number, all_files_marked)
+
+            local new_line_text = get_marked_line(line_text, all_files_marked)
             set_highlighted_text(file_list_buf, i, new_line_text, search_string)
         end
     end


### PR DESCRIPTION
## Problem

Initially in the development of the plugin, the "x" keybind only worked when marking occurrences and the "a" keybind was used to mark whole files. Eventually the behavior of the "x" keybind was changed to toggle occurrences and files to make it easier to work around.

This invalidated the use of the "a" keybind since all its functionality was copied by the "x" keybind.

## Solution

The functionality of the "a" keybind has changed from toggling the occurrences in a whole file to toggling the occurrences of the whole list of occurrences in all the files where a match was found. This was a feature I was missing while testing and repurposing the "a" keybind to do that feels natural.