### PR TITLE
Fixes behavior when an empty input is given

### DIFF
--- a/lua/rip/init.lua
+++ b/lua/rip/init.lua
@@ -59,7 +59,9 @@ function get_user_inputs()
     replace_string = vim.fn.input("Replace: ")
 
     if replace_string == "" then
-        return false
+        -- Leaving the replace string empty is a valid input since the user might
+        -- want to delete the search string
+        return true
     end
 
     return true

--- a/lua/rip/init.lua
+++ b/lua/rip/init.lua
@@ -26,13 +26,25 @@ local keybinds = {
 }
 
 function replace_in_project()
-    get_user_inputs()
+    local has_input = get_user_inputs()
+
+    if not has_input then
+        return
+        vim.cmd("echo ''")
+    end
+
     local searched_files = vim.fn.system("find . -type f -exec grep -n -H -e '" .. search_string .. "' {} +")
     replace_in_project_generic(searched_files)
 end
 
 function replace_in_git()
-    get_user_inputs()
+    local has_input = get_user_inputs()
+
+    if not has_input then
+        vim.cmd("echo ''")
+        return
+    end
+
     local searched_files = vim.fn.system("git ls-files | xargs grep -n -H -e '" .. search_string .. "'")
     replace_in_project_generic(searched_files)
 end
@@ -41,14 +53,16 @@ function get_user_inputs()
     search_string = vim.fn.input("Search: ")
 
     if search_string == "" then
-        return
+        return false
     end
 
     replace_string = vim.fn.input("Replace: ")
 
     if replace_string == "" then
-        return
+        return false
     end
+
+    return true
 end
 
 function replace_in_project_generic(files_searched)


### PR DESCRIPTION
## Problem

Yet another bug from the early versions of the software. Previously the `get_user_inputs()` function was not encapsulated in it's own function, so the `return` statements in it really blocked the rest of the plugin pipeline from going through. Now that it is a encapsulated function, the `return` statements only prevent the next input to be collected but the rest of the plugin (opening the window and etc) still executes with the empty string.

TLDR: If you just ESC/Enter out of the search input, the window with the occurrences would still open even though it doesn't make sense.

## Solution

Now the `get_user_inputs()` returns a `boolean` that tells its caller if the input collected is valid or not. With this I can cancel the plugin execution from the `replace_in_project` or `replace_in_git` functions, preventing the window to be open like  I expect.

https://github.com/lucaspellegrinelli/rip.nvim/blob/8fa7fe30940f5ad2917d710a85f9e15d9c65b691/lua/rip/init.lua#L41-L46

The `echo` in the end just clears the `Search:` or `Replace:` text in the bottom.